### PR TITLE
chore: add .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# JetBrains IDEs (IntelliJ, Rider, etc.)
+.idea/


### PR DESCRIPTION
添加 JetBrains IDE 的 .idea/ 目录到 .gitignore，防止 Rider 和其他 JetBrains IDE 的配置文件被 git 跟踪。

**Changes:**
- 在 JetBrains Rider 段落下方添加  到 .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)